### PR TITLE
docs(github): add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,74 @@
+name: Reporte de bug
+description: Informa sobre un comportamiento inesperado o error en el bot
+labels: ["bug"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Comprobación previa
+      options:
+        - label: He buscado en los issues existentes y esto no es un duplicado
+          required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Descripción del bug
+      description: Describe claramente el problema que encontraste
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Pasos para reproducir
+      description: Indica los pasos exactos para reproducir el comportamiento
+      placeholder: |
+        1. Ejecutar el comando '...'
+        2. Con los parámetros '...'
+        3. Observar el error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Comportamiento esperado
+      description: ¿Qué esperabas que ocurriera?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Comportamiento actual
+      description: ¿Qué ocurrió realmente?
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Entorno
+      description: Sistema operativo, versión del bot, versión de Node/Bun
+      placeholder: "macOS 14, mariwano v1.3.1, Bun 1.1.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severidad
+      options:
+        - Baja
+        - Media
+        - Alta
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Capturas de pantalla o logs
+      description: Adjunta capturas o logs relevantes si los tienes
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Solicitud de nueva funcionalidad o mejora
+description: Propón una nueva característica o mejora para el bot
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+    attributes:
+      label: Comprobación previa
+      options:
+        - label: He buscado en los issues existentes y esto no es un duplicado
+          required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Problema o motivación
+      description: ¿Qué problema resuelve esta propuesta? ¿Por qué sería útil?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solución propuesta
+      description: Describe cómo te imaginas que debería funcionar
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternativas consideradas
+      description: ¿Qué otras opciones barajaste antes de llegar a esta propuesta?
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexto adicional
+      description: Información extra, enlaces, capturas de pantalla u otros recursos relevantes
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Adds YAML issue forms for bug reports and feature requests under `.github/ISSUE_TEMPLATE/`
- Disables blank issue creation to enforce structured reporting
- Templates are in Spanish, consistent with the rest of the project documentation

Closes #76