### PR TITLE
fix(rank-memes): contar el total de reacciones en vez de tipos de emoji distintos

### DIFF
--- a/src/events/ready/rankMemes.ts
+++ b/src/events/ready/rankMemes.ts
@@ -52,16 +52,22 @@ async function collectMessages(targetChannel: TextChannel, cutoffDate: Date) {
       return;
    }
 
-   memeMessages.sort((a, b) => b.reactions.cache.size - a.reactions.cache.size);
+   // Fetch each reaction to ensure counts are up-to-date for messages that predate the bot session,
+   // then sum reaction.count across all emoji types to get the true total reaction count per message.
+   await Promise.all(memeMessages.map(message => Promise.all(message.reactions.cache.map(reaction => reaction.fetch()))));
+
+   const totalReactions = (message: Message) => message.reactions.cache.reduce((sum, reaction) => sum + reaction.count, 0);
+
+   memeMessages.sort((a, b) => totalReactions(b) - totalReactions(a));
    const firstWinner = memeMessages[0];
    const secondWinner = memeMessages[1];
    const thirdWinner = memeMessages[2];
 
    leaderboardEmbed
       .setDescription(
-         `🥇TOP 1: ${firstWinner.author} con ${firstWinner.reactions.cache.size} reacciones: ${firstWinner.url}` +
-            `\n🥈TOP 2: ${secondWinner.author} con ${secondWinner.reactions.cache.size} reacciones: ${secondWinner.url}` +
-            `\n🥉TOP 3: ${thirdWinner.author} con ${thirdWinner.reactions.cache.size} reacciones: ${thirdWinner.url}`
+         `🥇TOP 1: ${firstWinner.author} con ${totalReactions(firstWinner)} reacciones: ${firstWinner.url}` +
+            `\n🥈TOP 2: ${secondWinner.author} con ${totalReactions(secondWinner)} reacciones: ${secondWinner.url}` +
+            `\n🥉TOP 3: ${thirdWinner.author} con ${totalReactions(thirdWinner)} reacciones: ${thirdWinner.url}`
       )
       .setFooter({
          text: `Enhorabuena al ganador del top 1 por haber ganado el premio de ${

--- a/src/events/ready/rankMemes.ts
+++ b/src/events/ready/rankMemes.ts
@@ -52,8 +52,6 @@ async function collectMessages(targetChannel: TextChannel, cutoffDate: Date) {
       return;
    }
 
-   // Fetch each reaction to ensure counts are up-to-date for messages that predate the bot session,
-   // then sum reaction.count across all emoji types to get the true total reaction count per message.
    await Promise.all(memeMessages.map(message => Promise.all(message.reactions.cache.map(reaction => reaction.fetch()))));
 
    const totalReactions = (message: Message) => message.reactions.cache.reduce((sum, reaction) => sum + reaction.count, 0);


### PR DESCRIPTION
Closes #135

## Resumen

- Llama a `reaction.fetch()` en todas las reacciones de cada mensaje antes de ordenar, garantizando que `reaction.count` esté actualizado incluso para mensajes anteriores al arranque del bot.
- Sustituye `reactions.cache.size` (número de tipos de emoji) por la suma de `reaction.count` en todos los tipos, obteniendo el total real de reacciones de usuarios.
- Actualiza el embed del leaderboard para mostrar ese total correcto.

## Archivos modificados

- `src/events/ready/rankMemes.ts`