### PR TITLE
fix(economy): use getUser method for balance command options

### DIFF
--- a/src/commands/economy/balance.ts
+++ b/src/commands/economy/balance.ts
@@ -1,4 +1,4 @@
-import { SlashCommandBuilder } from 'discord.js';
+import { MessageFlags, SlashCommandBuilder } from 'discord.js';
 import { CommandProps } from '../../lib/types';
 import { User } from '../../models/User';
 
@@ -7,14 +7,20 @@ export const run = async ({ interaction }: CommandProps) => {
       if (!interaction.guild) {
          await interaction.reply({
             content: 'Sólo puedes ejecutar este comando dentro de un servidor.',
-            ephemeral: true,
+            flags: MessageFlags.Ephemeral,
          });
          return;
       }
 
-      await interaction.deferReply({ ephemeral: true });
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
-      const targetUserId = interaction.options.get('user')?.value || interaction.member?.user.id;
+      const targetUser = interaction.options.getUser('user');
+      const targetUserId = targetUser?.id || interaction.member?.user.id;
+
+      if (!targetUserId) {
+         await interaction.editReply('No se ha podido obtener el ID del usuario.');
+         return;
+      }
 
       const user = await User.findOne({
          userId: targetUserId,
@@ -22,17 +28,19 @@ export const run = async ({ interaction }: CommandProps) => {
       });
 
       if (!user) {
-         interaction.editReply(`<@${targetUserId}> no tiene un perfil todavía. Usa /daily para reclamar la paga diaria.`);
+         await interaction.editReply(`<@${targetUserId}> no tiene un perfil todavía. Usa /daily para reclamar la paga diaria.`);
          return;
       }
 
-      interaction.editReply(
-         targetUserId === interaction.member?.user.id
+      const currentUserId = interaction.member?.user.id;
+      await interaction.editReply(
+         targetUserId === currentUserId
             ? `Tienes ${user.balance} gramos de cocaína.`
             : `Los gramos de cocaína de <@${targetUserId}> son ${user.balance}.`
       );
    } catch (error) {
       console.error(`Hubo un error al ejecutar el comando 'balance': ${error}`);
+      throw error;
    }
 };
 


### PR DESCRIPTION
## Summary

Fixes the `/balance` command that was throwing an unknown error when called.

## Root Cause

The command had several issues:
1. Using `interaction.options.get('user')?.value` instead of `interaction.options.getUser('user')` for user options
2. Deprecated `ephemeral: true` flag instead of `MessageFlags.Ephemeral`
3. Missing `await` on `interaction.editReply()` calls
4. Error not being re-thrown in catch block

## Changes

- Changed to `interaction.options.getUser('user')` to properly retrieve user option
- Updated ephemeral replies to use `MessageFlags.Ephemeral`
- Added `await` to all `interaction.editReply()` calls
- Added `throw error` to properly propagate errors

Closes #148